### PR TITLE
Add Ant Design Pro blog archive page

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "antd": "^5.22.4",
+    "@ant-design/pro-components": "^2.7.12",
+    "@ant-design/icons": "^5.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,21 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { ProList } from '@ant-design/pro-components'
+import React from 'react'
+import { blogs } from './data/blogs'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <ProList
+      rowKey="id"
+      headerTitle="Nogizaka46 Blog Archive"
+      dataSource={blogs}
+      metas={{
+        title: { dataIndex: 'title' },
+        description: { dataIndex: 'member' },
+        extra: { dataIndex: 'date' },
+        content: { dataIndex: 'content' },
+      }}
+    />
   )
 }
 

--- a/src/data/blogs.js
+++ b/src/data/blogs.js
@@ -1,0 +1,23 @@
+export const blogs = [
+  {
+    id: 1,
+    title: 'Hajimemashite',
+    member: 'Ikuta Erika',
+    date: '2023-01-15',
+    content: 'First post from Erika, sharing her thoughts with fans.'
+  },
+  {
+    id: 2,
+    title: 'Concert memories',
+    member: 'Saito Asuka',
+    date: '2023-02-02',
+    content: 'Asuka talks about the recent concert and behind-the-scenes.'
+  },
+  {
+    id: 3,
+    title: 'Daily life',
+    member: 'Shiraishi Mai',
+    date: '2023-03-20',
+    content: 'Mai shares some everyday moments with fans.'
+  }
+]

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import 'antd/dist/reset.css'
+import '@ant-design/pro-components/dist/components.css'
 import './index.css'
 import App from './App.jsx'
 


### PR DESCRIPTION
## Summary
- list blog entries for Nogizaka46 members using Ant Design Pro `ProList`
- include sample blog data and Ant Design styles
- add Ant Design and Pro Components dependencies

## Testing
- `npm install --package-lock-only --registry=https://registry.npmmirror.com` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c2c42518508320a10c635340be4c4b