### PR TITLE
feat: enhance blog pages with ant design pro

### DIFF
--- a/src/components/BlogDetail.jsx
+++ b/src/components/BlogDetail.jsx
@@ -7,7 +7,7 @@ import {
   ShareAltOutlined,
 } from "@ant-design/icons";
 import { useState, useEffect } from "react";
-import { fetchBlogDetail, getImageUrl } from "../services/blogService";
+import { fetchBlogDetail } from "../services/blogService";
 
 const { Title, Text } = Typography;
 

--- a/src/components/BlogList.jsx
+++ b/src/components/BlogList.jsx
@@ -1,26 +1,13 @@
 import { useNavigate } from "react-router-dom";
-import {
-  Typography,
-  Image,
-  Spin,
-  Empty,
-  Button,
-  Card,
-  Space,
-  Avatar,
-  Tooltip,
-  Tag,
-} from "antd";
+import { Typography, Image, Spin, Empty, Button, Avatar, Tooltip, Tag } from "antd";
 import {
   CalendarOutlined,
-  EyeOutlined,
   HeartOutlined,
   ReadOutlined,
   ClockCircleOutlined,
-  UserOutlined,
   StarOutlined,
 } from "@ant-design/icons";
-import { ProList, ProCard } from "@ant-design/pro-components";
+import { ProList, ProCard, PageContainer } from "@ant-design/pro-components";
 import { useState, useEffect } from "react";
 import { fetchAllBlogs, getImageUrl } from "../services/blogService";
 
@@ -94,9 +81,9 @@ const BlogList = () => {
   }
 
   return (
-    <div className="p-6 min-h-screen">
-      <div className="max-w-6xl mx-auto">
-        {/* Header Section */}
+    <PageContainer
+      className="p-6 min-h-screen"
+      pageHeaderRender={() => (
         <div className="text-center mb-8 animate-fade-in">
           <div className="relative inline-block">
             <Title className="text-6xl font-bold bg-gradient-to-r from-purple-600 via-pink-600 to-purple-600 bg-clip-text text-transparent mb-2 drop-shadow-sm">
@@ -124,120 +111,121 @@ const BlogList = () => {
             </span>
           </div>
         </div>
+      )}
+    >
+      {blogs.length === 0 ? (
+        <div className="flex justify-center">
+          <Empty
+            description="まだブログ記事がありません"
+            className="bg-white/80 backdrop-blur-sm p-12 rounded-2xl shadow-lg border border-gray-100"
+          />
+        </div>
+      ) : (
+        <ProList
+          grid={{ gutter: 16, xs: 1, sm: 2, lg: 3 }}
+          metas={{}}
+          dataSource={blogs}
+          renderItem={(blog, index) => (
+            <ProCard
+              key={blog.id}
+              hoverable
+              onClick={() => handleBlogClick(blog.id)}
+              className="group cursor-pointer transform transition-all duration-300 hover:scale-105 hover:shadow-2xl bg-white/90 backdrop-blur-sm border-0 overflow-hidden"
+              style={{ animationDelay: `${index * 100}ms` }}
+              bodyStyle={{ padding: 0 }}
+            >
+              {/* Image Cover */}
+              <div className="relative h-48 overflow-hidden bg-gradient-to-br from-purple-100 to-pink-100">
+                <Image
+                  alt={blog.title}
+                  src={
+                    blog.thumbnail
+                      ? getImageUrl(blog.thumbnail)
+                      : "https://via.placeholder.com/400x200/9c27b0/ffffff?text=No+Image"
+                  }
+                  className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
+                  preview={false}
+                  fallback="https://via.placeholder.com/400x200/9c27b0/ffffff?text=No+Image"
+                  onError={(e) => {
+                    e.target.src =
+                      "https://via.placeholder.com/400x200/9c27b0/ffffff?text=No+Image";
+                  }}
+                />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
 
-        {blogs.length === 0 ? (
-          <div className="flex justify-center">
-            <Empty
-              description="まだブログ記事がありません"
-              className="bg-white/80 backdrop-blur-sm p-12 rounded-2xl shadow-lg border border-gray-100"
-            />
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 animate-slide-up">
-            {blogs.map((blog, index) => (
-              <ProCard
-                key={blog.id}
-                hoverable
-                onClick={() => handleBlogClick(blog.id)}
-                className="group cursor-pointer transform transition-all duration-300 hover:scale-105 hover:shadow-2xl bg-white/90 backdrop-blur-sm border-0 overflow-hidden"
-                style={{
-                  animationDelay: `${index * 100}ms`,
-                }}
-                bodyStyle={{ padding: 0 }}
-              >
-                {/* Image Cover */}
-                <div className="relative h-48 overflow-hidden bg-gradient-to-br from-purple-100 to-pink-100">
-                  <Image
-                    alt={blog.title}
-                    src={
-                      blog.thumbnail
-                        ? getImageUrl(blog.thumbnail)
-                        : "https://via.placeholder.com/400x200/9c27b0/ffffff?text=No+Image"
-                    }
-                    className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
-                    preview={false}
-                    fallback="https://via.placeholder.com/400x200/9c27b0/ffffff?text=No+Image"
+                {/* Date Badge */}
+                <div className="absolute top-3 right-3">
+                  <Tag className="bg-white/90 backdrop-blur-sm border-0 shadow-lg rounded-full px-3 py-1 text-xs font-medium">
+                    {blog.date}
+                  </Tag>
+                </div>
+              </div>
+              {/* Content */}
+              <div className="p-5 space-y-4">
+                {/* Author Info */}
+                <div className="flex items-center space-x-3">
+                  <Avatar
+                    src="https://www.nogizaka46.com/images/46/d21/1d87f2203680137df7346b7551ed0.jpg"
+                    size={36}
+                    className="ring-2 ring-purple-100"
                     onError={(e) => {
                       e.target.src =
-                        "https://via.placeholder.com/400x200/9c27b0/ffffff?text=No+Image";
+                        "https://www.nogizaka46.com/images/46/d21/1d87f2203680137df7346b7551ed0.jpg";
                     }}
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-
-                  {/* Date Badge */}
-                  <div className="absolute top-3 right-3">
-                    <Tag className="bg-white/90 backdrop-blur-sm border-0 shadow-lg rounded-full px-3 py-1 text-xs font-medium">
-                      {blog.date}
-                    </Tag>
-                  </div>
-                </div>
-                {/* Content */}
-                <div className="p-5 space-y-4">
-                  {/* Author Info */}
-                  <div className="flex items-center space-x-3">
-                    <Avatar
-                      src="https://www.nogizaka46.com/images/46/d21/1d87f2203680137df7346b7551ed0.jpg"
-                      size={36}
-                      className="ring-2 ring-purple-100"
-                      onError={(e) => {
-                        e.target.src =
-                          "https://www.nogizaka46.com/images/46/d21/1d87f2203680137df7346b7551ed0.jpg";
-                      }}
-                    />
-                    <div>
-                      <Text className="text-sm font-medium text-gray-700">
-                        一ノ瀬 美空
-                      </Text>
-                      <div className="flex items-center space-x-1 text-xs text-gray-500">
-                        <ClockCircleOutlined />
-                        <span>{blog.date}</span>
-                      </div>
+                  <div>
+                    <Text className="text-sm font-medium text-gray-700">
+                      一ノ瀬 美空
+                    </Text>
+                    <div className="flex items-center space-x-1 text-xs text-gray-500">
+                      <ClockCircleOutlined />
+                      <span>{blog.date}</span>
                     </div>
                   </div>
+                </div>
 
-                  {/* Title */}
-                  <Title
-                    level={5}
-                    className="m-0 text-gray-800 font-semibold leading-snug line-clamp-2 group-hover:text-purple-600 transition-colors duration-200"
+                {/* Title */}
+                <Title
+                  level={5}
+                  className="m-0 text-gray-800 font-semibold leading-snug line-clamp-2 group-hover:text-purple-600 transition-colors duration-200"
+                >
+                  {blog.title}
+                </Title>
+
+                {/* Action Buttons */}
+                <div className="flex justify-between items-center pt-2 border-t border-gray-100">
+                  <div className="flex space-x-4">
+                    <Tooltip title="Read Blog">
+                      <Button
+                        type="text"
+                        icon={<ReadOutlined />}
+                        size="small"
+                        className="text-purple-600 hover:text-purple-700 hover:bg-purple-50"
+                      />
+                    </Tooltip>
+                    <Tooltip title="Like">
+                      <Button
+                        type="text"
+                        icon={<HeartOutlined />}
+                        size="small"
+                        className="text-pink-600 hover:text-pink-700 hover:bg-pink-50"
+                      />
+                    </Tooltip>
+                  </div>
+                  <Button
+                    type="primary"
+                    size="small"
+                    className="bg-gradient-to-r from-purple-600 to-pink-600 border-0 rounded-full px-4"
                   >
-                    {blog.title}
-                  </Title>
-
-                  {/* Action Buttons */}
-                  <div className="flex justify-between items-center pt-2 border-t border-gray-100">
-                    <div className="flex space-x-4">
-                      <Tooltip title="Read Blog">
-                        <Button
-                          type="text"
-                          icon={<ReadOutlined />}
-                          size="small"
-                          className="text-purple-600 hover:text-purple-700 hover:bg-purple-50"
-                        />
-                      </Tooltip>
-                      <Tooltip title="Like">
-                        <Button
-                          type="text"
-                          icon={<HeartOutlined />}
-                          size="small"
-                          className="text-pink-600 hover:text-pink-700 hover:bg-pink-50"
-                        />
-                      </Tooltip>
-                    </div>
-                    <Button
-                      type="primary"
-                      size="small"
-                      className="bg-gradient-to-r from-purple-600 to-pink-600 border-0 rounded-full px-4"
-                    >
-                      読む
-                    </Button>
-                  </div>
+                    読む
+                  </Button>
                 </div>
-              </ProCard>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
+              </div>
+            </ProCard>
+          )}
+        />
+      )}
+    </PageContainer>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace manual blog list grid with Ant Design Pro's PageContainer and ProList for a cleaner layout
- remove unused blog detail import to satisfy linter

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2e8771ccc832084b77fe9bc1752ec