### PR TITLE
fix: load member info and blogs reliably on iOS

### DIFF
--- a/src/services/blogService.js
+++ b/src/services/blogService.js
@@ -97,13 +97,15 @@ const fetchBlogPage = async (page, memberCode) => {
       const imgElement = $(element).find(".m--bg.js-bg");
       const img = imgElement.attr("data-src") || "";
 
+      const author = $(element).find(".bl--card__name").text().trim();
+
       blogs.push({
         id: blogId,
         title,
         date,
         link: `${BASE_URL}${link}`,
         thumbnail: img,
-        author: "一ノ瀬 美空",
+        author,
       });
     });
 

--- a/src/utils/deviceDetection.js
+++ b/src/utils/deviceDetection.js
@@ -45,7 +45,6 @@ export const getUserAgent = () => {
   }
 };
 
-// Check if we should use proxy (iOS Safari has stricter CORS)
-export const shouldUseProxy = () => {
-  return isIOS() || isSafari();
-};
+// Always use the proxy to avoid CORS issues across browsers
+// This fixes missing data on iOS where direct requests are blocked
+export const shouldUseProxy = () => true;


### PR DESCRIPTION
## Summary
- always use proxy for all requests to avoid iOS/Safari CORS blocks
- parse author names from blog list cards instead of hardcoding

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c68f4e7e8883209c86890751a87aca