### PR TITLE
fix: load member info and blogs reliably on iOS

### DIFF
--- a/src/services/blogService.js
+++ b/src/services/blogService.js
@@ -97,13 +97,15 @@ const fetchBlogPage = async (page, memberCode) => {
       const imgElement = $(element).find(".m--bg.js-bg");
       const img = imgElement.attr("data-src") || "";
 
+      const author = $(element).find(".bl--card__name").text().trim();
+
       blogs.push({
         id: blogId,
         title,
         date,
         link: `${BASE_URL}${link}`,
         thumbnail: img,
-        author: "一ノ瀬 美空",
+        author,
       });
     });
 
@@ -275,18 +277,32 @@ export const fetchBlogDetail = async (blogId) => {
     const author = $(".bd--prof__name").text().trim();
     console.log("Author name from blog:", author);
 
-    // Fetch member info to get correct image sử dụng proxy
-    let memberData;
-    if (shouldUseProxy()) {
-      try {
-        memberData = await fetchWithProxy("/s/n46/api/list/member", {
-          callback: "res",
-        });
-      } catch (proxyError) {
-        console.warn(
-          "Proxy failed for member info, trying direct request:",
-          proxyError
-        );
+    // Try to fetch member info for avatar image, but don't block on failure
+    let memberImage = null;
+    try {
+      let memberData;
+      if (shouldUseProxy()) {
+        try {
+          memberData = await fetchWithProxy("/s/n46/api/list/member", {
+            callback: "res",
+          });
+        } catch (proxyError) {
+          console.warn(
+            "Proxy failed for member info, trying direct request:",
+            proxyError
+          );
+          const response = await axios.get(
+            `${BASE_URL}/s/n46/api/list/member?callback=res`,
+            {
+              responseType: "text",
+              headers: {
+                "User-Agent": getUserAgent(),
+              },
+            }
+          );
+          memberData = response.data;
+        }
+      } else {
         const response = await axios.get(
           `${BASE_URL}/s/n46/api/list/member?callback=res`,
           {
@@ -298,22 +314,16 @@ export const fetchBlogDetail = async (blogId) => {
         );
         memberData = response.data;
       }
-    } else {
-      const response = await axios.get(
-        `${BASE_URL}/s/n46/api/list/member?callback=res`,
-        {
-          responseType: "text",
-          headers: {
-            "User-Agent": getUserAgent(),
-          },
-        }
-      );
-      memberData = response.data;
-    }
 
-    const jsonStr = memberData.replace(/^res\(/, "").replace(/\);?$/, "");
-    const memberApi = JSON.parse(jsonStr);
-    const memberInfo = memberApi.data.find((m) => m.code === memberCode);
+      if (memberData) {
+        const jsonStr = memberData.replace(/^res\(/, "").replace(/\);?$/, "");
+        const memberApi = JSON.parse(jsonStr);
+        const memberInfo = memberApi.data.find((m) => m.code === memberCode);
+        memberImage = memberInfo?.img || null;
+      }
+    } catch (memberError) {
+      console.warn("Failed to fetch member info:", memberError);
+    }
 
     // Get original URL
     const originalUrl = `${BASE_URL}/s/n46/diary/detail/${blogId}?cd=MEMBER`;
@@ -325,7 +335,7 @@ export const fetchBlogDetail = async (blogId) => {
       content: content.html() || "",
       memberCode,
       author,
-      memberImage: memberInfo?.img || null,
+      memberImage,
       originalUrl,
     };
 

--- a/src/utils/deviceDetection.js
+++ b/src/utils/deviceDetection.js
@@ -45,7 +45,6 @@ export const getUserAgent = () => {
   }
 };
 
-// Check if we should use proxy (iOS Safari has stricter CORS)
-export const shouldUseProxy = () => {
-  return isIOS() || isSafari();
-};
+// Always use the proxy to avoid CORS issues across browsers
+// This fixes missing data on iOS where direct requests are blocked
+export const shouldUseProxy = () => true;


### PR DESCRIPTION
## Summary
- always use proxy for all requests to avoid iOS/Safari CORS blocks
- parse author names from blog list cards instead of hardcoding
- skip member info image fetch when request fails

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c68f4e7e8883209c86890751a87aca